### PR TITLE
Expand range to include zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navigators-exploration-team/mina-mastermind",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "description": "",
   "author": "navigators-exploration-team",
   "license": "Apache-2.0",

--- a/src/test/Mastermind.test.ts
+++ b/src/test/Mastermind.test.ts
@@ -886,7 +886,6 @@ describe('Mastermind ZkApp Tests', () => {
         REWARD_AMOUNT = 1e10;
       });
 
-
       it('Reject initGame with invalid secret: first digit is greater than 7', async () => {
         const expectedMsg = 'Combination digit 1 is not in range [0, 7]!';
         await expectInitializeGameToFail(
@@ -898,7 +897,6 @@ describe('Mastermind ZkApp Tests', () => {
           expectedMsg
         );
       });
-
 
       it('Reject initGame with invalid secret: second digit is greater than 7', async () => {
         const expectedMsg = 'Combination digit 2 is not in range [0, 7]!';
@@ -998,8 +996,7 @@ describe('Mastermind ZkApp Tests', () => {
       });
 
       it('Should reject codeMaster with invalid secret combination: all digits same', async () => {
-        const expectedErrorMessage =
-          'Combination digit 2 is not unique!';
+        const expectedErrorMessage = 'Combination digit 2 is not unique!';
         await expectInitializeGameToFail(
           zkapp,
           codeMasterKey,

--- a/src/test/Mastermind.test.ts
+++ b/src/test/Mastermind.test.ts
@@ -886,20 +886,9 @@ describe('Mastermind ZkApp Tests', () => {
         REWARD_AMOUNT = 1e10;
       });
 
-      it('Reject initGame with invalid secret: first digit is 0', async () => {
-        const expectedMsg = 'Combination digit 1 is not in range [1, 7]!';
-        await expectInitializeGameToFail(
-          zkapp,
-          codeMasterKey,
-          [0, 1, 2, 3],
-          codeMasterSalt,
-          refereeKey,
-          expectedMsg
-        );
-      });
 
       it('Reject initGame with invalid secret: first digit is greater than 7', async () => {
-        const expectedMsg = 'Combination digit 1 is not in range [1, 7]!';
+        const expectedMsg = 'Combination digit 1 is not in range [0, 7]!';
         await expectInitializeGameToFail(
           zkapp,
           codeMasterKey,
@@ -910,20 +899,9 @@ describe('Mastermind ZkApp Tests', () => {
         );
       });
 
-      it('Reject initGame with invalid secret: second digit is 0', async () => {
-        const expectedMsg = 'Combination digit 2 is not in range [1, 7]!';
-        await expectInitializeGameToFail(
-          zkapp,
-          codeMasterKey,
-          [7, 0, 2, 5],
-          codeMasterSalt,
-          refereeKey,
-          expectedMsg
-        );
-      });
 
       it('Reject initGame with invalid secret: second digit is greater than 7', async () => {
-        const expectedMsg = 'Combination digit 2 is not in range [1, 7]!';
+        const expectedMsg = 'Combination digit 2 is not in range [0, 7]!';
         await expectInitializeGameToFail(
           zkapp,
           codeMasterKey,
@@ -934,20 +912,8 @@ describe('Mastermind ZkApp Tests', () => {
         );
       });
 
-      it('Reject initGame with invalid secret: third digit is 0', async () => {
-        const expectedMsg = 'Combination digit 3 is not in range [1, 7]!';
-        await expectInitializeGameToFail(
-          zkapp,
-          codeMasterKey,
-          [7, 1, 0, 5],
-          codeMasterSalt,
-          refereeKey,
-          expectedMsg
-        );
-      });
-
       it('Reject initGame with invalid secret: third digit is greater than 7', async () => {
-        const expectedMsg = 'Combination digit 3 is not in range [1, 7]!';
+        const expectedMsg = 'Combination digit 3 is not in range [0, 7]!';
         await expectInitializeGameToFail(
           zkapp,
           codeMasterKey,
@@ -958,20 +924,8 @@ describe('Mastermind ZkApp Tests', () => {
         );
       });
 
-      it('Reject initGame with invalid secret: fourth digit is 0', async () => {
-        const expectedMsg = 'Combination digit 4 is not in range [1, 7]!';
-        await expectInitializeGameToFail(
-          zkapp,
-          codeMasterKey,
-          [3, 1, 2, 0],
-          codeMasterSalt,
-          refereeKey,
-          expectedMsg
-        );
-      });
-
       it('Reject initGame with invalid secret: fourth digit is greater than 7', async () => {
-        const expectedMsg = 'Combination digit 4 is not in range [1, 7]!';
+        const expectedMsg = 'Combination digit 4 is not in range [0, 7]!';
         await expectInitializeGameToFail(
           zkapp,
           codeMasterKey,
@@ -1032,7 +986,7 @@ describe('Mastermind ZkApp Tests', () => {
 
       it('Should reject codeMaster with invalid secret combination: all digits same and exceeding 7', async () => {
         const expectedErrorMessage =
-          'Combination digit 1 is not in range [1, 7]!';
+          'Combination digit 1 is not in range [0, 7]!';
         await expectInitializeGameToFail(
           zkapp,
           codeMasterKey,
@@ -1043,9 +997,9 @@ describe('Mastermind ZkApp Tests', () => {
         );
       });
 
-      it('Should reject codeMaster with invalid secret combination: all digits same and equal 0', async () => {
+      it('Should reject codeMaster with invalid secret combination: all digits same', async () => {
         const expectedErrorMessage =
-          'Combination digit 1 is not in range [1, 7]!';
+          'Combination digit 2 is not unique!';
         await expectInitializeGameToFail(
           zkapp,
           codeMasterKey,

--- a/src/test/stepProgram.test.ts
+++ b/src/test/stepProgram.test.ts
@@ -194,51 +194,30 @@ describe('Mastermind ZkProgram Tests', () => {
 
   describe('Invalid game creation', () => {
     describe('Invalid range of digits', () => {
-      it('Should reject codeMaster with invalid secret combination: first digit is 0', async () => {
-        const expectedErrorMessage =
-          'Combination digit 1 is not in range [1, 7]!';
-        await expectCreateGameToFail([0, 2, 3, 4], expectedErrorMessage);
-      });
 
-      it('Should reject codeMaster with invalid secret combination: second digit is 0', async () => {
-        const expectedErrorMessage =
-          'Combination digit 2 is not in range [1, 7]!';
-        await expectCreateGameToFail([5, 0, 4, 6], expectedErrorMessage);
-      });
 
-      it('Should reject codeMaster with invalid secret combination: third digit is 0', async () => {
-        const expectedErrorMessage =
-          'Combination digit 3 is not in range [1, 7]!';
-        await expectCreateGameToFail([7, 1, 0, 6], expectedErrorMessage);
-      });
-
-      it('Should reject codeMaster with invalid secret combination: fourth digit is 0', async () => {
-        const expectedErrorMessage =
-          'Combination digit 4 is not in range [1, 7]!';
-        await expectCreateGameToFail([2, 3, 4, 0], expectedErrorMessage);
-      });
 
       it('Should reject codeMaster with invalid secret combination: first digit is greater than 7', async () => {
         const expectedErrorMessage =
-          'Combination digit 1 is not in range [1, 7]!';
+          'Combination digit 1 is not in range [0, 7]!';
         await expectCreateGameToFail([8, 2, 3, 4], expectedErrorMessage);
       });
 
       it('Should reject codeMaster with invalid secret combination: second digit is greater than 7', async () => {
         const expectedErrorMessage =
-          'Combination digit 2 is not in range [1, 7]!';
+          'Combination digit 2 is not in range [0, 7]!';
         await expectCreateGameToFail([6, 9, 3, 4], expectedErrorMessage);
       });
 
       it('Should reject codeMaster with invalid secret combination: third digit is greater than 7', async () => {
         const expectedErrorMessage =
-          'Combination digit 3 is not in range [1, 7]!';
+          'Combination digit 3 is not in range [0, 7]!';
         await expectCreateGameToFail([2, 3, 10, 4], expectedErrorMessage);
       });
 
       it('Should reject codeMaster with invalid secret combination: fourth digit is greater than 7', async () => {
         const expectedErrorMessage =
-          'Combination digit 4 is not in range [1, 7]!';
+          'Combination digit 4 is not in range [0, 7]!';
         await expectCreateGameToFail([3, 6, 2, 11], expectedErrorMessage);
       });
     });
@@ -284,44 +263,24 @@ describe('Mastermind ZkProgram Tests', () => {
     });
 
     describe('Invalid guess', () => {
-      it('Should reject codeBreaker with invalid guess combination: first digit is 0', async () => {
-        const expectedErrorMessage =
-          'Combination digit 1 is not in range [1, 7]!';
-        await expectMakeGuessToFail([0, 2, 3, 4], expectedErrorMessage);
-      });
       it('Should reject codeBreaker with invalid guess combination: first digit is greater than 7', async () => {
         const expectedErrorMessage =
-          'Combination digit 1 is not in range [1, 7]!';
+          'Combination digit 1 is not in range [0, 7]!';
         await expectMakeGuessToFail([8, 2, 3, 4], expectedErrorMessage);
-      });
-      it('Should reject codeBreaker with invalid guess combination: second digit is 0', async () => {
-        const expectedErrorMessage =
-          'Combination digit 2 is not in range [1, 7]!';
-        await expectMakeGuessToFail([1, 0, 3, 4], expectedErrorMessage);
       });
       it('Should reject codeBreaker with invalid guess combination: second digit is greater than 7', async () => {
         const expectedErrorMessage =
-          'Combination digit 2 is not in range [1, 7]!';
+          'Combination digit 2 is not in range [0, 7]!';
         await expectMakeGuessToFail([1, 9, 3, 4], expectedErrorMessage);
-      });
-      it('Should reject codeBreaker with invalid guess combination: third digit is 0', async () => {
-        const expectedErrorMessage =
-          'Combination digit 3 is not in range [1, 7]!';
-        await expectMakeGuessToFail([1, 2, 0, 4], expectedErrorMessage);
       });
       it('Should reject codeBreaker with invalid guess combination: third digit is greater than 7', async () => {
         const expectedErrorMessage =
-          'Combination digit 3 is not in range [1, 7]!';
+          'Combination digit 3 is not in range [0, 7]!';
         await expectMakeGuessToFail([1, 2, 10, 4], expectedErrorMessage);
-      });
-      it('Should reject codeBreaker with invalid guess combination: fourth digit is 0', async () => {
-        const expectedErrorMessage =
-          'Combination digit 4 is not in range [1, 7]!';
-        await expectMakeGuessToFail([1, 2, 3, 0], expectedErrorMessage);
       });
       it('Should reject codeBreaker with invalid guess combination: fourth digit is greater than 7', async () => {
         const expectedErrorMessage =
-          'Combination digit 4 is not in range [1, 7]!';
+          'Combination digit 4 is not in range [0, 7]!';
         await expectMakeGuessToFail([1, 2, 3, 12], expectedErrorMessage);
       });
       it('Should reject codeBreaker with invalid guess combination: second digit is not unique', async () => {

--- a/src/test/stepProgram.test.ts
+++ b/src/test/stepProgram.test.ts
@@ -194,9 +194,6 @@ describe('Mastermind ZkProgram Tests', () => {
 
   describe('Invalid game creation', () => {
     describe('Invalid range of digits', () => {
-
-
-
       it('Should reject codeMaster with invalid secret combination: first digit is greater than 7', async () => {
         const expectedErrorMessage =
           'Combination digit 1 is not in range [0, 7]!';

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -64,29 +64,17 @@ describe('utility.ts unit tests', () => {
         );
       });
 
-      it('should throw an error if the digits are above from range [1, 7]', () => {
+      it('should throw an error if the digits are above from range [0, 7]', () => {
         const combinationNumbers = [1, 2, 3, 8];
         expect(() => Combination.from(combinationNumbers)).toThrow(
-          'Combination digit 4 is not in range [1, 7]!'
-        );
-      });
-      it('should throw an error if the digits are below from range [1, 7]', () => {
-        const combinationNumbers = [1, 0, 3, 4];
-        expect(() => Combination.from(combinationNumbers)).toThrow(
-          'Combination digit 2 is not in range [1, 7]!'
+          'Combination digit 4 is not in range [0, 7]!'
         );
       });
 
-      it('should throw an error if the digits are not unique and above from range [1, 7]', () => {
+      it('should throw an error if the digits are not unique and above from range [0, 7]', () => {
         const combinationNumbers = [1, 1, 3, 8];
         expect(() => Combination.from(combinationNumbers)).toThrow(
-          'Combination digit 4 is not in range [1, 7]!'
-        );
-      });
-      it('should throw an error if the digits are not unique and below from range [1, 7]', () => {
-        const combinationNumbers = [1, 2, 2, 0];
-        expect(() => Combination.from(combinationNumbers)).toThrow(
-          'Combination digit 4 is not in range [1, 7]!'
+          'Combination digit 4 is not in range [0, 7]!'
         );
       });
     });
@@ -335,30 +323,14 @@ describe('utility.ts unit tests', () => {
           digits: [1, 2, 3, 8].map(Field),
         });
         expect(() => combination.validate()).toThrow(
-          'Combination digit 4 is not in range [1, 7]!'
+          'Combination digit 4 is not in range [0, 7]!'
         );
 
         const combination2 = new Combination({
           digits: [1, 2, 3, 9].map(Field),
         });
         expect(() => combination2.validate()).toThrow(
-          'Combination digit 4 is not in range [1, 7]!'
-        );
-      });
-
-      it('should throw an error for a combination with digits below range', () => {
-        const combination = new Combination({
-          digits: [1, 0, 3, 4].map(Field),
-        });
-        expect(() => combination.validate()).toThrow(
-          'Combination digit 2 is not in range [1, 7]!'
-        );
-
-        const combination2 = new Combination({
-          digits: [0, 2, 3, 4].map(Field),
-        });
-        expect(() => combination2.validate()).toThrow(
-          'Combination digit 1 is not in range [1, 7]!'
+          'Combination digit 4 is not in range [0, 7]!'
         );
       });
 
@@ -367,7 +339,7 @@ describe('utility.ts unit tests', () => {
           digits: [1, 1, 3, 8].map(Field),
         });
         expect(() => combination.validate()).toThrow(
-          'Combination digit 4 is not in range [1, 7]!'
+          'Combination digit 4 is not in range [0, 7]!'
         );
       });
 
@@ -376,7 +348,7 @@ describe('utility.ts unit tests', () => {
           digits: [1, 2, 2, 8].map(Field),
         });
         expect(() => combination.validate()).toThrow(
-          'Combination digit 4 is not in range [1, 7]!'
+          'Combination digit 4 is not in range [0, 7]!'
         );
       });
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ export { Combination, Clue, GameState };
  * @method `toBits` - Converts the combination to a bit array.
  * @method `compress` - Compresses the combination into a single field element.
  * @method `decompress` - Decompresses the combination from a single field element.
- * @method `validate` - Validates the combination to ensure all digits are unique and within the range [1, 7].
+ * @method `validate` - Validates the combination to ensure all digits are unique and within the range [0, 7].
  * @method `updateHistory` - Updates the history of combinations with the new combination.
  * @method `getElementFromHistory` - Retrieves an element from the history based on the index.
  */
@@ -54,9 +54,8 @@ class Combination extends Struct({
   validate() {
     for (let i = 0; i < 4; i++) {
       this.digits[i]
-        .equals(0)
-        .or(this.digits[i].greaterThan(7))
-        .assertFalse(`Combination digit ${i + 1} is not in range [1, 7]!`);
+        .greaterThan(7)
+        .assertFalse(`Combination digit ${i + 1} is not in range [0, 7]!`);
     }
 
     for (let i = 1; i < 4; i++) {


### PR DESCRIPTION
####  Changes:

- **Updated validation logic** in the `Combination` class:
  - Modified the `validate()` method to allow `0` as a valid digit.
  - Replaced:
    ```ts
    this.digits[i].equals(0).or(this.digits[i].greaterThan(7)).assertFalse()
    ```
    with:
    ```ts
    this.digits[i].greaterThan(7).assertFalse()
    ```
- **Removed tests** that asserted `0` was invalid, as `0` is now a valid guess.
