### PR TITLE
Broken maxAttemptExceeded fix and unique solutionhash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navigators-exploration-team/mina-mastermind",
-  "version": "1.4.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@navigators-exploration-team/mina-mastermind",
-      "version": "1.4.0",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navigators-exploration-team/mina-mastermind",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "",
   "author": "navigators-exploration-team",
   "license": "Apache-2.0",

--- a/src/benchmark/benchmark.md
+++ b/src/benchmark/benchmark.md
@@ -15,10 +15,10 @@ This report summarizes the circuit analysis, compilation times, and per-step ben
 
 | Method     | Rows |
 | ---------- | ---- |
-| createGame | 523  |
-| giveClue   | 653  |
-| makeGuess  | 821  |
-| **Total**  | 1997 |
+| createGame | 536  |
+| giveClue   | 679  |
+| makeGuess  | 820  |
+| **Total**  | 2035 |
 
 ---
 
@@ -26,14 +26,14 @@ This report summarizes the circuit analysis, compilation times, and per-step ben
 
 | Method          | Rows  |
 | --------------- | ----- |
-| initGame        | 1337  |
-| acceptGame      | 1494  |
-| submitGameProof | 1319  |
-| claimReward     | 1372  |
-| forfeitWin      | 1419  |
-| makeGuess       | 1576  |
-| giveClue        | 1588  |
-| **Total**       | 10105 |
+| initGame        | 1349  |
+| acceptGame      | 1557  |
+| submitGameProof | 1377  |
+| claimReward     | 1463  |
+| forfeitWin      | 1435  |
+| makeGuess       | 1626  |
+| giveClue        | 1665  |
+| **Total**       | 10472 |
 
 ### Compilation Times
 

--- a/src/benchmark/browser/app/worker/worker.ts
+++ b/src/benchmark/browser/app/worker/worker.ts
@@ -300,10 +300,12 @@ const functions = {
         authSignature: Signature.create(state.codeMasterKey!, [
           ...state.secretCombination!.digits,
           state.codeMasterSalt!,
+          ...state.zkapp!.address.toFields(),
         ]),
       },
       state.secretCombination!,
-      state.codeMasterSalt!
+      state.codeMasterSalt!,
+      state.zkapp!.address
     );
     end = performance.now();
     state.benchmarkResults.baseGameSeconds = (end - start) / 1000;
@@ -318,10 +320,12 @@ const functions = {
             authSignature: Signature.create(state.codeBreakerKey!, [
               ...step.digits,
               proof.publicOutput.turnCount.value,
+              ...state.zkapp!.address.toFields(),
             ]),
           },
           proof,
-          step
+          step,
+          state.zkapp!.address
         )
       ).proof;
       end = performance.now();
@@ -337,11 +341,13 @@ const functions = {
               ...state.secretCombination!.digits,
               state.codeMasterSalt!,
               proof.publicOutput.turnCount.value,
+              ...state.zkapp!.address.toFields(),
             ]),
           },
           proof,
           state.secretCombination!,
-          state.codeMasterSalt!
+          state.codeMasterSalt!,
+          state.zkapp!.address
         )
       ).proof;
       end = performance.now();

--- a/src/benchmark/node/benchmark.ts
+++ b/src/benchmark/node/benchmark.ts
@@ -458,10 +458,12 @@ async function solveBenchmark(secret: number[], steps: Combination[]) {
         authSignature: Signature.create(codeMasterKey, [
           ...secretCombination.digits,
           codeMasterSalt,
+          ...zkappAddress.toFields(),
         ]),
       },
       secretCombination,
-      codeMasterSalt
+      codeMasterSalt,
+      zkappAddress
     )
   ).proof;
   end = performance.now();
@@ -477,10 +479,12 @@ async function solveBenchmark(secret: number[], steps: Combination[]) {
           authSignature: Signature.create(codeBreakerKey, [
             ...step.digits,
             lastProof.publicOutput.turnCount.value,
+            ...zkappAddress.toFields(),
           ]),
         },
         lastProof,
-        step
+        step,
+        zkappAddress
       )
     ).proof;
     end = performance.now();
@@ -495,11 +499,13 @@ async function solveBenchmark(secret: number[], steps: Combination[]) {
             ...secretCombination.digits,
             codeMasterSalt,
             lastProof.publicOutput.turnCount.value,
+            ...zkappAddress.toFields(),
           ]),
         },
         lastProof,
         secretCombination,
-        codeMasterSalt
+        codeMasterSalt,
+        zkappAddress
       )
     ).proof;
     end = performance.now();

--- a/src/stepProgram.ts
+++ b/src/stepProgram.ts
@@ -55,23 +55,32 @@ const StepProgram = ZkProgram({
      * @returns the proof of the new game and the public output.
      */
     createGame: {
-      privateInputs: [Combination, Field],
+      privateInputs: [Combination, Field, PublicKey],
       async method(
         authInputs: PublicInputs,
         secretCombination: Combination,
-        salt: Field
+        salt: Field,
+        contractAddress: PublicKey
       ) {
         secretCombination.validate();
 
         authInputs.authSignature
-          .verify(authInputs.authPubKey, [...secretCombination.digits, salt])
+          .verify(authInputs.authPubKey, [
+            ...secretCombination.digits,
+            salt,
+            ...contractAddress.toFields(),
+          ])
           .assertTrue('Invalid signature!');
 
         return {
           publicOutput: new PublicOutputs({
             codeMasterId: Poseidon.hash(authInputs.authPubKey.toFields()),
             codeBreakerId: Field.from(0),
-            solutionHash: Poseidon.hash([...secretCombination.digits, salt]),
+            solutionHash: Poseidon.hash([
+              ...secretCombination.digits,
+              salt,
+              ...contractAddress.toFields(),
+            ]),
             lastCompressedGuess: Field.from(0),
             lastcompressedClue: Field.from(0),
             turnCount: UInt8.from(1),
@@ -92,11 +101,12 @@ const StepProgram = ZkProgram({
      * The codeBreaker can only make a guess if it is their turn and the secret combination is not solved yet, and if they have not reached the limit number of attempts.
      */
     makeGuess: {
-      privateInputs: [SelfProof, Combination],
+      privateInputs: [SelfProof, Combination, PublicKey],
       async method(
         authInputs: PublicInputs,
         previousClue: SelfProof<PublicInputs, PublicOutputs>,
-        guessCombination: Combination
+        guessCombination: Combination,
+        contractAddress: PublicKey
       ) {
         previousClue.verify();
         guessCombination.validate();
@@ -120,6 +130,7 @@ const StepProgram = ZkProgram({
           .verify(authInputs.authPubKey, [
             ...guessCombination.digits,
             turnCount,
+            ...contractAddress.toFields(),
           ])
           .assertTrue('Invalid signature!');
 
@@ -156,12 +167,13 @@ const StepProgram = ZkProgram({
      * The codeMaster can only give a clue if it is their turn and the secret combination is not solved yet, and if they have not reached the limit number of attempts.
      */
     giveClue: {
-      privateInputs: [SelfProof, Combination, Field],
+      privateInputs: [SelfProof, Combination, Field, PublicKey],
       async method(
         authInputs: PublicInputs,
         previousGuess: SelfProof<PublicInputs, PublicOutputs>,
         secretCombination: Combination,
-        salt: Field
+        salt: Field,
+        contractAddress: PublicKey
       ) {
         previousGuess.verify();
 
@@ -178,7 +190,11 @@ const StepProgram = ZkProgram({
         );
 
         previousGuess.publicOutput.solutionHash.assertEquals(
-          Poseidon.hash([...secretCombination.digits, salt]),
+          Poseidon.hash([
+            ...secretCombination.digits,
+            salt,
+            ...contractAddress.toFields(),
+          ]),
           'The secret combination is not compliant with the initial hash from game creation!'
         );
 
@@ -187,6 +203,7 @@ const StepProgram = ZkProgram({
             ...secretCombination.digits,
             salt,
             turnCount,
+            ...contractAddress.toFields(),
           ])
           .assertTrue('Invalid signature!');
 

--- a/src/stepProgram.ts
+++ b/src/stepProgram.ts
@@ -52,6 +52,7 @@ const StepProgram = ZkProgram({
      * Signature message should be the concatenation of the **secret combination** digits and `salt`.
      * @param secretCombination secret combination to be solved by the codeBreaker.
      * @param salt the salt to be used in the hash function to prevent pre-image attacks.
+     * @param contractAddress the address of the corresponding contract.
      * @returns the proof of the new game and the public output.
      */
     createGame: {
@@ -97,6 +98,7 @@ const StepProgram = ZkProgram({
      * Signature message should be the concatenation of the `guessCombination` and `turnCount`.
      * @param previousClue the proof of the previous game state. It contains the last clue given by the codeMaster.
      * @param guessCombination the guess made by the codeBreaker.
+     * @param contractAddress the address of the corresponding contract.
      * @returns the proof of the updated game state and the public output.
      * The codeBreaker can only make a guess if it is their turn and the secret combination is not solved yet, and if they have not reached the limit number of attempts.
      */
@@ -163,6 +165,7 @@ const StepProgram = ZkProgram({
      * @param previousGuess the proof of the previous game state. It contains the last guess made by the codeBreaker.
      * @param secretCombination the secret combination to be solved by the codeBreaker.
      * @param salt the salt to be used in the hash function to prevent pre-image attacks.
+     * @param contractAddress the address of the corresponding contract.
      * @returns the proof of the updated game state and the public output.
      * The codeMaster can only give a clue if it is their turn and the secret combination is not solved yet, and if they have not reached the limit number of attempts.
      */

--- a/src/test/Mastermind.test.ts
+++ b/src/test/Mastermind.test.ts
@@ -2329,6 +2329,24 @@ describe('Mastermind ZkApp Tests', () => {
       ).toEqual(15n);
     });
 
+    it('Code breaker should not be able to continue game with makeGuess', async () => {
+      const guessCombination = Combination.from([3, 1, 5, 2]);
+      await expectMakeGuessToFail(
+        codeBreakerPubKey,
+        codeBreakerKey,
+        guessCombination,
+        'The game secret has already been solved!'
+      );
+    });
+
+    it('Code master should not be able to claim reward', async () => {
+      await expectClaimRewardToFail(
+        codeMasterPubKey,
+        codeMasterKey,
+        'You are not the winner of this game!'
+      );
+    });
+
     it('Claim reward', async () => {
       await claimReward(codeBreakerPubKey, codeBreakerKey);
     });

--- a/src/test/Mastermind.test.ts
+++ b/src/test/Mastermind.test.ts
@@ -1288,15 +1288,6 @@ describe('Mastermind ZkApp Tests', () => {
     });
 
     it('Submit with partial game proof', async () => {
-      console.log(partialProof.publicOutput.solutionHash.toBigInt());
-      console.log(zkapp.solutionHash.get().toBigInt());
-      console.log(
-        Poseidon.hash([
-          ...Combination.from(secretCombination).digits,
-          codeMasterSalt,
-          ...zkappAddress.toFields(),
-        ]).toBigInt()
-      );
       await submitGameProof(partialProof, codeBreakerPubKey, false);
     });
 

--- a/src/test/Mastermind.test.ts
+++ b/src/test/Mastermind.test.ts
@@ -18,14 +18,13 @@ import { GameState, Clue, Combination } from '../utils';
 import { StepProgram, StepProgramProof } from '../stepProgram';
 
 import {
-  gameGuesses,
   generateTestProofs,
   StepProgramCreateGame,
   StepProgramGiveClue,
   StepProgramMakeGuess,
 } from './testUtils';
 import { players } from './mock';
-import { PER_TURN_GAME_DURATION } from '../constants';
+import { MAX_ATTEMPTS, PER_TURN_GAME_DURATION } from '../constants';
 
 describe('Mastermind ZkApp Tests', () => {
   // Global variables
@@ -658,6 +657,82 @@ describe('Mastermind ZkApp Tests', () => {
     }
   }
 
+  async function correctProofGeneration() {
+    secretCombination = [1, 2, 3, 4];
+    // Build a "completedProof" that solves the game
+    // This portion uses your StepProgram to create valid proofs off-chain.
+
+    // 1. createGame
+    partialProof = await StepProgramCreateGame(
+      secretCombination,
+      codeMasterSalt,
+      codeMasterKey,
+      zkappAddress
+    );
+
+    // 2. makeGuess
+    partialProof = await StepProgramMakeGuess(
+      partialProof,
+      [2, 1, 3, 4],
+      codeBreakerKey,
+      zkappAddress
+    );
+
+    // 3. giveClue
+    partialProof = await StepProgramGiveClue(
+      partialProof,
+      secretCombination,
+      codeMasterSalt,
+      codeMasterKey,
+      zkappAddress
+    );
+
+    // 4. second guess
+    completedProof = await StepProgramMakeGuess(
+      partialProof,
+      secretCombination,
+      codeBreakerKey,
+      zkappAddress
+    );
+
+    // 5. giveClue & final
+    completedProof = await StepProgramGiveClue(
+      completedProof,
+      secretCombination,
+      codeMasterSalt,
+      codeMasterKey,
+      zkappAddress
+    );
+  }
+
+  async function wrongProofGeneration() {
+    const secretCombination = [7, 1, 6, 3];
+    // Base case: Create a new game
+    wrongProof = await StepProgramCreateGame(
+      secretCombination,
+      codeMasterSalt,
+      codeMasterKey,
+      zkappAddress
+    );
+
+    // Make a guess with wrong answer
+    wrongProof = await StepProgramMakeGuess(
+      wrongProof,
+      secretCombination,
+      codeBreakerKey,
+      zkappAddress
+    );
+
+    // Give clue with wrong answer
+    wrongProof = await StepProgramGiveClue(
+      wrongProof,
+      secretCombination,
+      codeMasterSalt,
+      codeMasterKey,
+      zkappAddress
+    );
+  }
+
   beforeAll(async () => {
     // Compile StepProgram and MastermindZkApp
     await StepProgram.compile({
@@ -731,79 +806,18 @@ describe('Mastermind ZkApp Tests', () => {
 
     // Initialize codeMasterSalt & secret combination
     codeMasterSalt = Field.random();
-    secretCombination = [7, 1, 6, 3];
 
     // Prepare brand-new MastermindZkApp for tests
     zkappPrivateKey = PrivateKey.random();
     zkappAddress = zkappPrivateKey.toPublicKey();
     zkapp = new MastermindZkApp(zkappAddress);
-
-    // Base case: Create a new game
-    wrongProof = await StepProgramCreateGame(
-      secretCombination,
-      codeMasterSalt,
-      codeMasterKey
-    );
-
-    // Make a guess with wrong answer
-    wrongProof = await StepProgramMakeGuess(
-      wrongProof,
-      secretCombination,
-      codeBreakerKey
-    );
-
-    // Give clue with wrong answer
-    wrongProof = await StepProgramGiveClue(
-      wrongProof,
-      secretCombination,
-      codeMasterSalt,
-      codeMasterKey
-    );
-
-    secretCombination = [1, 2, 3, 4];
-
-    // Build a "completedProof" that solves the game
-    // This portion uses your StepProgram to create valid proofs off-chain.
-
-    // 1. createGame
-    partialProof = await StepProgramCreateGame(
-      secretCombination,
-      codeMasterSalt,
-      codeMasterKey
-    );
-
-    // 2. makeGuess
-    partialProof = await StepProgramMakeGuess(
-      partialProof,
-      [2, 1, 3, 4],
-      codeBreakerKey
-    );
-
-    // 3. giveClue
-    partialProof = await StepProgramGiveClue(
-      partialProof,
-      secretCombination,
-      codeMasterSalt,
-      codeMasterKey
-    );
-
-    // 4. second guess
-    completedProof = await StepProgramMakeGuess(
-      partialProof,
-      secretCombination,
-      codeBreakerKey
-    );
-
-    // 5. giveClue & final
-    completedProof = await StepProgramGiveClue(
-      completedProof,
-      secretCombination,
-      codeMasterSalt,
-      codeMasterKey
-    );
   });
 
   describe('Deploy & Initialize Flow', () => {
+    beforeAll(async () => {
+      await wrongProofGeneration();
+      secretCombination = [1, 2, 3, 4];
+    });
     beforeEach(() => {
       log(expect.getState().currentTestName);
     });
@@ -1034,6 +1048,7 @@ describe('Mastermind ZkApp Tests', () => {
         Poseidon.hash([
           ...Combination.from(secretCombination).digits,
           codeMasterSalt,
+          ...zkappAddress.toFields(),
         ])
       );
 
@@ -1062,6 +1077,10 @@ describe('Mastermind ZkApp Tests', () => {
   });
 
   describe('Accepting a Game and Solve', () => {
+    beforeAll(async () => {
+      await wrongProofGeneration();
+      await correctProofGeneration();
+    });
     beforeEach(() => {
       log(expect.getState().currentTestName);
     });
@@ -1261,6 +1280,7 @@ describe('Mastermind ZkApp Tests', () => {
   describe('Submitting Correct Game Proof and Claiming Reward', () => {
     beforeAll(async () => {
       await prepareNewGame();
+      await correctProofGeneration();
     });
 
     beforeEach(() => {
@@ -1268,6 +1288,15 @@ describe('Mastermind ZkApp Tests', () => {
     });
 
     it('Submit with partial game proof', async () => {
+      console.log(partialProof.publicOutput.solutionHash.toBigInt());
+      console.log(zkapp.solutionHash.get().toBigInt());
+      console.log(
+        Poseidon.hash([
+          ...Combination.from(secretCombination).digits,
+          codeMasterSalt,
+          ...zkappAddress.toFields(),
+        ]).toBigInt()
+      );
       await submitGameProof(partialProof, codeBreakerPubKey, false);
     });
 
@@ -1459,227 +1488,360 @@ describe('Mastermind ZkApp Tests', () => {
       await prepareNewGame();
     });
 
-    it('Should generate a proof with randomly chosen actions for codeMaster victory and settle.', async () => {
-      const rounds = 7;
-      const winnerFlag = 'codemaster-victory';
+    describe('lower test cases', () => {
+      it('1 round not solved', async () => {
+        const proof = await generateTestProofs(
+          'unsolved',
+          1,
+          codeMasterSalt,
+          secretCombination,
+          codeBreakerKey,
+          codeMasterKey,
+          zkappAddress
+        );
 
-      const expectedMsg = 'You are not the winner of this game!';
+        await submitGameProof(proof, codeBreakerPubKey, false);
 
-      const CMVictoryProof = await generateTestProofs(
-        winnerFlag,
-        rounds,
-        codeMasterSalt,
-        secretCombination,
-        codeBreakerKey,
-        codeMasterKey
-      );
+        const { turnCount, isSolved } = GameState.unpack(
+          zkapp.compressedState.get()
+        );
 
-      const publicOutputs = CMVictoryProof.publicOutput;
+        expect(proof.publicOutput.solutionHash).toEqual(
+          zkapp.solutionHash.get()
+        );
+        expect(turnCount.toBigInt()).toEqual(
+          proof.publicOutput.turnCount.toBigInt()
+        );
+        expect(isSolved.toBoolean()).toEqual(false);
+        expect(zkapp.codeBreakerId.get()).toEqual(
+          Poseidon.hash(codeBreakerPubKey.toFields())
+        );
 
-      await submitGameProof(CMVictoryProof, codeMasterPubKey, true);
+        expect(turnCount.toBigInt()).toEqual(3n);
 
-      const { turnCount, isSolved } = GameState.unpack(
-        zkapp.compressedState.get()
-      );
+        await expectClaimRewardToFail(
+          codeBreakerPubKey,
+          codeBreakerKey,
+          'You are not the winner of this game!'
+        );
+      });
 
-      expect(publicOutputs.solutionHash).toEqual(zkapp.solutionHash.get());
-      expect(turnCount.toBigInt()).toEqual(publicOutputs.turnCount.toBigInt());
-      expect(isSolved.toBoolean()).toEqual(false);
-      expect(zkapp.codeBreakerId.get()).toEqual(
-        Poseidon.hash(codeBreakerPubKey.toFields())
-      );
+      it('1 round solved claim on submit', async () => {
+        const proof = await generateTestProofs(
+          'codebreaker-victory',
+          1,
+          codeMasterSalt,
+          secretCombination,
+          codeBreakerKey,
+          codeMasterKey,
+          zkappAddress
+        );
 
-      await expectClaimRewardToFail(
-        codeBreakerPubKey,
-        codeBreakerKey,
-        expectedMsg
-      );
+        await submitGameProof(proof, codeBreakerPubKey, true);
+
+        const { turnCount, isSolved } = GameState.unpack(
+          zkapp.compressedState.get()
+        );
+
+        expect(proof.publicOutput.solutionHash).toEqual(
+          zkapp.solutionHash.get()
+        );
+        expect(turnCount.toBigInt()).toEqual(
+          proof.publicOutput.turnCount.toBigInt()
+        );
+        expect(isSolved.toBoolean()).toEqual(true);
+        expect(zkapp.codeBreakerId.get()).toEqual(
+          Poseidon.hash(codeBreakerPubKey.toFields())
+        );
+
+        expect(turnCount.toBigInt()).toEqual(3n);
+      });
+
+      it('1 round solved claim after', async () => {
+        const proof = await generateTestProofs(
+          'codebreaker-victory',
+          1,
+          codeMasterSalt,
+          secretCombination,
+          codeBreakerKey,
+          codeMasterKey,
+          zkappAddress
+        );
+
+        await submitGameProof(proof, codeMasterPubKey, false);
+
+        const { turnCount, isSolved } = GameState.unpack(
+          zkapp.compressedState.get()
+        );
+
+        expect(proof.publicOutput.solutionHash).toEqual(
+          zkapp.solutionHash.get()
+        );
+        expect(turnCount.toBigInt()).toEqual(
+          proof.publicOutput.turnCount.toBigInt()
+        );
+        expect(isSolved.toBoolean()).toEqual(true);
+        expect(zkapp.codeBreakerId.get()).toEqual(
+          Poseidon.hash(codeBreakerPubKey.toFields())
+        );
+
+        expect(turnCount.toBigInt()).toEqual(3n);
+
+        await expectClaimRewardToFail(
+          codeMasterPubKey,
+          codeMasterKey,
+          'You are not the winner of this game!'
+        );
+      });
     });
 
-    it('Should generate a proof with predefined actions for codeMaster victory and settle.', async () => {
-      const rounds = 7;
-      const winnerFlag = 'codemaster-victory';
+    describe('middle test cases', () => {
+      it('4 round not solved', async () => {
+        const proof = await generateTestProofs(
+          'unsolved',
+          4,
+          codeMasterSalt,
+          secretCombination,
+          codeBreakerKey,
+          codeMasterKey,
+          zkappAddress
+        );
 
-      const expectedMsg = 'You are not the winner of this game!';
+        await submitGameProof(proof, codeBreakerPubKey, false);
 
-      const CMVictoryProof = await generateTestProofs(
-        winnerFlag,
-        rounds,
-        codeMasterSalt,
-        secretCombination,
-        codeBreakerKey,
-        codeMasterKey,
-        gameGuesses
-      );
+        const { turnCount, isSolved } = GameState.unpack(
+          zkapp.compressedState.get()
+        );
 
-      const publicOutputs = CMVictoryProof.publicOutput;
+        expect(proof.publicOutput.solutionHash).toEqual(
+          zkapp.solutionHash.get()
+        );
+        expect(turnCount.toBigInt()).toEqual(
+          proof.publicOutput.turnCount.toBigInt()
+        );
+        expect(isSolved.toBoolean()).toEqual(false);
+        expect(zkapp.codeBreakerId.get()).toEqual(
+          Poseidon.hash(codeBreakerPubKey.toFields())
+        );
 
-      await submitGameProof(CMVictoryProof, codeMasterPubKey, true);
+        expect(turnCount.toBigInt()).toEqual(9n);
 
-      const { turnCount, isSolved } = GameState.unpack(
-        zkapp.compressedState.get()
-      );
+        await expectClaimRewardToFail(
+          codeBreakerPubKey,
+          codeBreakerKey,
+          'You are not the winner of this game!'
+        );
+      });
 
-      const attemptList = gameGuesses.totalAttempts.slice(0, rounds);
-      const separatedHistory = Array.from({ length: rounds }, (_, i) =>
-        Combination.getElementFromHistory(
-          zkapp.packedGuessHistory.get(),
-          Field(i)
-        ).digits.map(Number)
-      );
+      it('5 round solved claim on submit', async () => {
+        const proof = await generateTestProofs(
+          'codebreaker-victory',
+          5,
+          codeMasterSalt,
+          secretCombination,
+          codeBreakerKey,
+          codeMasterKey,
+          zkappAddress
+        );
 
-      expect(separatedHistory).toEqual(attemptList);
-      expect(publicOutputs.solutionHash).toEqual(zkapp.solutionHash.get());
+        await submitGameProof(proof, codeBreakerPubKey, true);
 
-      expect(turnCount.toBigInt()).toEqual(publicOutputs.turnCount.toBigInt());
+        const { turnCount, isSolved } = GameState.unpack(
+          zkapp.compressedState.get()
+        );
 
-      expect(isSolved.toBoolean()).toEqual(false);
+        expect(proof.publicOutput.solutionHash).toEqual(
+          zkapp.solutionHash.get()
+        );
+        expect(turnCount.toBigInt()).toEqual(
+          proof.publicOutput.turnCount.toBigInt()
+        );
+        expect(isSolved.toBoolean()).toEqual(true);
+        expect(zkapp.codeBreakerId.get()).toEqual(
+          Poseidon.hash(codeBreakerPubKey.toFields())
+        );
 
-      expect(zkapp.codeBreakerId.get()).toEqual(
-        Poseidon.hash(codeBreakerPubKey.toFields())
-      );
+        expect(turnCount.toBigInt()).toEqual(11n);
+      });
 
-      await expectClaimRewardToFail(
-        codeBreakerPubKey,
-        codeBreakerKey,
-        expectedMsg
-      );
+      it('3 round solved claim after', async () => {
+        const proof = await generateTestProofs(
+          'codebreaker-victory',
+          3,
+          codeMasterSalt,
+          secretCombination,
+          codeBreakerKey,
+          codeMasterKey,
+          zkappAddress
+        );
+
+        await submitGameProof(proof, codeMasterPubKey, false);
+
+        const { turnCount, isSolved } = GameState.unpack(
+          zkapp.compressedState.get()
+        );
+
+        expect(proof.publicOutput.solutionHash).toEqual(
+          zkapp.solutionHash.get()
+        );
+        expect(turnCount.toBigInt()).toEqual(
+          proof.publicOutput.turnCount.toBigInt()
+        );
+        expect(isSolved.toBoolean()).toEqual(true);
+        expect(zkapp.codeBreakerId.get()).toEqual(
+          Poseidon.hash(codeBreakerPubKey.toFields())
+        );
+
+        expect(turnCount.toBigInt()).toEqual(7n);
+
+        await expectClaimRewardToFail(
+          codeMasterPubKey,
+          codeMasterKey,
+          'You are not the winner of this game!'
+        );
+      });
     });
 
-    it('Should generate a proof with randomly chosen actions for codeBreaker victory and settle.', async () => {
-      const rounds = 3;
-      const winnerFlag = 'codebreaker-victory';
+    describe('upper test cases', () => {
+      it('MAX_ATTEMPTS round not solved claim on submit', async () => {
+        const proof = await generateTestProofs(
+          'codemaster-victory',
+          MAX_ATTEMPTS,
+          codeMasterSalt,
+          secretCombination,
+          codeBreakerKey,
+          codeMasterKey,
+          zkappAddress
+        );
 
-      const expectedMsg = 'You are not the winner of this game!';
+        await submitGameProof(proof, codeMasterPubKey, true);
 
-      const CBVictoryProof = await generateTestProofs(
-        winnerFlag,
-        rounds,
-        codeMasterSalt,
-        secretCombination,
-        codeBreakerKey,
-        codeMasterKey
-      );
+        const { turnCount, isSolved } = GameState.unpack(
+          zkapp.compressedState.get()
+        );
 
-      await submitGameProof(CBVictoryProof, codeBreakerPubKey, true);
+        expect(proof.publicOutput.solutionHash).toEqual(
+          zkapp.solutionHash.get()
+        );
+        expect(turnCount.toBigInt()).toEqual(
+          proof.publicOutput.turnCount.toBigInt()
+        );
+        expect(isSolved.toBoolean()).toEqual(false);
+        expect(zkapp.codeBreakerId.get()).toEqual(
+          Poseidon.hash(codeBreakerPubKey.toFields())
+        );
 
-      const publicOutputs = CBVictoryProof.publicOutput;
+        expect(turnCount.toBigInt()).toEqual(BigInt(2 * MAX_ATTEMPTS + 1));
+      });
 
-      const { turnCount, isSolved } = GameState.unpack(
-        zkapp.compressedState.get()
-      );
+      it('MAX_ATTEMPTS round not solved claim after', async () => {
+        const proof = await generateTestProofs(
+          'codemaster-victory',
+          MAX_ATTEMPTS,
+          codeMasterSalt,
+          secretCombination,
+          codeBreakerKey,
+          codeMasterKey,
+          zkappAddress
+        );
 
-      expect(publicOutputs.solutionHash).toEqual(zkapp.solutionHash.get());
+        await submitGameProof(proof, codeBreakerPubKey, false);
 
-      expect(turnCount.toBigInt()).toEqual(publicOutputs.turnCount.toBigInt());
+        const { turnCount, isSolved } = GameState.unpack(
+          zkapp.compressedState.get()
+        );
 
-      expect(isSolved.toBoolean()).toEqual(true);
+        expect(proof.publicOutput.solutionHash).toEqual(
+          zkapp.solutionHash.get()
+        );
+        expect(turnCount.toBigInt()).toEqual(
+          proof.publicOutput.turnCount.toBigInt()
+        );
+        expect(isSolved.toBoolean()).toEqual(false);
+        expect(zkapp.codeBreakerId.get()).toEqual(
+          Poseidon.hash(codeBreakerPubKey.toFields())
+        );
 
-      expect(zkapp.codeBreakerId.get()).toEqual(
-        Poseidon.hash(codeBreakerPubKey.toFields())
-      );
+        expect(turnCount.toBigInt()).toEqual(BigInt(2 * MAX_ATTEMPTS + 1));
 
-      await expectClaimRewardToFail(
-        codeMasterPubKey,
-        codeMasterKey,
-        expectedMsg
-      );
-    });
+        await expectClaimRewardToFail(
+          codeBreakerPubKey,
+          codeBreakerKey,
+          'You are not the winner of this game!'
+        );
 
-    it('Should generate a proof with predefined actions for codeBreaker victory and settle.', async () => {
-      const rounds = 3;
-      const winnerFlag = 'codebreaker-victory';
+        await claimReward(codeMasterPubKey, codeMasterKey);
+      });
 
-      const expectedMsg = 'You are not the winner of this game!';
+      it('MAX_ATTEMPTS round solved claim on submit', async () => {
+        const proof = await generateTestProofs(
+          'codebreaker-victory',
+          MAX_ATTEMPTS,
+          codeMasterSalt,
+          secretCombination,
+          codeBreakerKey,
+          codeMasterKey,
+          zkappAddress
+        );
 
-      const CBVictoryProof = await generateTestProofs(
-        winnerFlag,
-        rounds,
-        codeMasterSalt,
-        secretCombination,
-        codeBreakerKey,
-        codeMasterKey,
-        gameGuesses
-      );
+        await submitGameProof(proof, codeBreakerPubKey, true);
 
-      await submitGameProof(CBVictoryProof, codeBreakerPubKey, true);
+        const { turnCount, isSolved } = GameState.unpack(
+          zkapp.compressedState.get()
+        );
 
-      const publicOutputs = CBVictoryProof.publicOutput;
+        expect(proof.publicOutput.solutionHash).toEqual(
+          zkapp.solutionHash.get()
+        );
+        expect(turnCount.toBigInt()).toEqual(
+          proof.publicOutput.turnCount.toBigInt()
+        );
+        expect(isSolved.toBoolean()).toEqual(true);
+        expect(zkapp.codeBreakerId.get()).toEqual(
+          Poseidon.hash(codeBreakerPubKey.toFields())
+        );
 
-      const { turnCount, isSolved } = GameState.unpack(
-        zkapp.compressedState.get()
-      );
+        expect(turnCount.toBigInt()).toEqual(BigInt(2 * MAX_ATTEMPTS + 1));
+      });
 
-      const attemptList = gameGuesses.totalAttempts.slice(0, rounds - 1);
+      it('MAX_ATTEMPTS round solved claim after', async () => {
+        const proof = await generateTestProofs(
+          'codebreaker-victory',
+          MAX_ATTEMPTS,
+          codeMasterSalt,
+          secretCombination,
+          codeBreakerKey,
+          codeMasterKey,
+          zkappAddress
+        );
 
-      const separatedHistory = Array.from({ length: rounds - 1 }, (_, i) =>
-        Combination.getElementFromHistory(
-          zkapp.packedGuessHistory.get(),
-          Field(i)
-        ).digits.map(Number)
-      );
+        await submitGameProof(proof, codeMasterPubKey, false);
 
-      expect(separatedHistory).toEqual(attemptList);
+        const { turnCount, isSolved } = GameState.unpack(
+          zkapp.compressedState.get()
+        );
 
-      expect(publicOutputs.solutionHash).toEqual(zkapp.solutionHash.get());
+        expect(proof.publicOutput.solutionHash).toEqual(
+          zkapp.solutionHash.get()
+        );
+        expect(turnCount.toBigInt()).toEqual(
+          proof.publicOutput.turnCount.toBigInt()
+        );
+        expect(isSolved.toBoolean()).toEqual(true);
+        expect(zkapp.codeBreakerId.get()).toEqual(
+          Poseidon.hash(codeBreakerPubKey.toFields())
+        );
 
-      expect(turnCount.toBigInt()).toEqual(publicOutputs.turnCount.toBigInt());
+        expect(turnCount.toBigInt()).toEqual(BigInt(2 * MAX_ATTEMPTS + 1));
 
-      expect(isSolved.toBoolean()).toEqual(true);
+        await expectClaimRewardToFail(
+          codeMasterPubKey,
+          codeMasterKey,
+          'You are not the winner of this game!'
+        );
 
-      expect(zkapp.codeBreakerId.get()).toEqual(
-        Poseidon.hash(codeBreakerPubKey.toFields())
-      );
-
-      await expectClaimRewardToFail(
-        codeMasterPubKey,
-        codeMasterKey,
-        expectedMsg
-      );
-    });
-
-    it('Should generate a proof with randomly chosen actions for unsolved game.', async () => {
-      const rounds = 3;
-      const expectedMsg = 'You are not the winner of this game!';
-      const winnerFlag = 'unsolved';
-
-      const unsolvedProof = await generateTestProofs(
-        winnerFlag,
-        rounds,
-        codeMasterSalt,
-        secretCombination,
-        codeBreakerKey,
-        codeMasterKey
-      );
-
-      const publicOutputs = unsolvedProof.publicOutput;
-
-      await submitGameProof(unsolvedProof, codeBreakerPubKey, false);
-
-      const { turnCount, finalizeSlot, isSolved } = GameState.unpack(
-        zkapp.compressedState.get()
-      );
-
-      expect(publicOutputs.solutionHash).toEqual(zkapp.solutionHash.get());
-      expect(turnCount.toBigInt()).toEqual(publicOutputs.turnCount.toBigInt());
-      expect(isSolved.toBoolean()).toEqual(false);
-      expect(zkapp.codeBreakerId.get()).toEqual(
-        Poseidon.hash(codeBreakerPubKey.toFields())
-      );
-      expect(
-        Mina.getNetworkState().globalSlotSinceGenesis.toBigint()
-      ).toBeLessThan(finalizeSlot.toBigint());
-
-      await expectClaimRewardToFail(
-        codeMasterPubKey,
-        codeMasterKey,
-        expectedMsg
-      );
-      await expectClaimRewardToFail(
-        codeBreakerPubKey,
-        codeBreakerKey,
-        expectedMsg
-      );
+        await claimReward(codeBreakerPubKey, codeBreakerKey);
+      });
     });
   });
 
@@ -1699,7 +1861,8 @@ describe('Mastermind ZkApp Tests', () => {
         codeMasterSalt,
         secretCombination,
         intruderKey,
-        codeMasterKey
+        codeMasterKey,
+        zkappAddress
       );
 
       const expectedMsg =
@@ -1714,7 +1877,8 @@ describe('Mastermind ZkApp Tests', () => {
         codeMasterSalt,
         secretCombination,
         codeBreakerKey,
-        intruderKey
+        intruderKey,
+        zkappAddress
       );
 
       const expectedMsg =
@@ -1729,7 +1893,8 @@ describe('Mastermind ZkApp Tests', () => {
         codeMasterSalt,
         [3, 6, 2, 7],
         codeBreakerKey,
-        codeMasterKey
+        codeMasterKey,
+        zkappAddress
       );
 
       const expectedMsg =
@@ -1744,7 +1909,8 @@ describe('Mastermind ZkApp Tests', () => {
         Field.random(),
         secretCombination,
         codeBreakerKey,
-        codeMasterKey
+        codeMasterKey,
+        zkappAddress
       );
 
       const expectedMsg =
@@ -1759,7 +1925,8 @@ describe('Mastermind ZkApp Tests', () => {
         codeMasterSalt,
         secretCombination,
         codeBreakerKey,
-        codeMasterKey
+        codeMasterKey,
+        zkappAddress
       );
 
       await submitGameProof(proof, codeBreakerPubKey, false);
@@ -1771,7 +1938,8 @@ describe('Mastermind ZkApp Tests', () => {
         codeMasterSalt,
         secretCombination,
         codeBreakerKey,
-        codeMasterKey
+        codeMasterKey,
+        zkappAddress
       );
       await expectProofSubmissionToFail(proof, codeBreakerPubKey, expectedMsg);
     });
@@ -1820,7 +1988,8 @@ describe('Mastermind ZkApp Tests', () => {
         codeMasterSalt,
         secretCombination,
         codeBreakerKey,
-        codeMasterKey
+        codeMasterKey,
+        zkappAddress
       );
       await submitGameProof(proof, codeMasterPubKey, false);
       slotNumber = await fetchSlotNumber();
@@ -1850,7 +2019,8 @@ describe('Mastermind ZkApp Tests', () => {
         codeMasterSalt,
         secretCombination,
         codeBreakerKey,
-        codeMasterKey
+        codeMasterKey,
+        zkappAddress
       );
       await submitGameProof(proof, codeBreakerPubKey, false);
       slotNumber = await fetchSlotNumber();

--- a/src/test/testUtils.test.ts
+++ b/src/test/testUtils.test.ts
@@ -1,4 +1,4 @@
-import { Field, Poseidon, PrivateKey } from 'o1js';
+import { Field, Poseidon, PrivateKey, PublicKey } from 'o1js';
 import {
   generateTestProofs,
   gameGuesses,
@@ -12,12 +12,14 @@ describe('Should generate StepProgramProof for given parameters', () => {
   let codeBreakerKey: PrivateKey;
   let codeMasterSalt: Field;
   let secret: number[];
+  let contractAddress: PublicKey;
 
   beforeAll(async () => {
     codeBreakerKey = PrivateKey.random();
     codeMasterKey = PrivateKey.random();
     codeMasterSalt = Field.random();
     secret = secretCombination;
+    contractAddress = PrivateKey.random().toPublicKey();
 
     await StepProgram.compile({
       proofsEnabled: false,
@@ -36,7 +38,8 @@ describe('Should generate StepProgramProof for given parameters', () => {
       salt,
       secret,
       codeBreakerKey,
-      codeMasterKey
+      codeMasterKey,
+      contractAddress
     );
 
     const publicOutputs = proof.publicOutput;
@@ -45,7 +48,11 @@ describe('Should generate StepProgramProof for given parameters', () => {
       proof.publicOutput.lastCompressedGuess
     ).digits;
 
-    const computedHash = Poseidon.hash([...outputNumbers, salt]);
+    const computedHash = Poseidon.hash([
+      ...outputNumbers,
+      salt,
+      ...contractAddress.toFields(),
+    ]);
 
     const solutionHash = proof.publicOutput.solutionHash;
     expect(solutionHash).not.toEqual(computedHash);
@@ -66,7 +73,8 @@ describe('Should generate StepProgramProof for given parameters', () => {
       salt,
       secret,
       codeBreakerKey,
-      codeMasterKey
+      codeMasterKey,
+      contractAddress
     );
 
     const publicOutputs = proof.publicOutput;
@@ -79,7 +87,11 @@ describe('Should generate StepProgramProof for given parameters', () => {
     const attemptList = actions.totalAttempts.slice(0, rounds - 1);
     attemptList.push(secretCombination);
 
-    const computedHash = Poseidon.hash([...outputNumbers, salt]);
+    const computedHash = Poseidon.hash([
+      ...outputNumbers,
+      salt,
+      ...contractAddress.toFields(),
+    ]);
     const solutionHash = publicOutputs.solutionHash;
 
     expect(solutionHash).toEqual(computedHash);
@@ -101,6 +113,7 @@ describe('Should generate StepProgramProof for given parameters', () => {
       secret,
       codeBreakerKey,
       codeMasterKey,
+      contractAddress,
       gameGuesses
     );
 
@@ -110,7 +123,11 @@ describe('Should generate StepProgramProof for given parameters', () => {
       proof.publicOutput.lastCompressedGuess
     ).digits;
 
-    const computedHash = Poseidon.hash([...outputNumbers, salt]);
+    const computedHash = Poseidon.hash([
+      ...outputNumbers,
+      salt,
+      ...contractAddress.toFields(),
+    ]);
     const solutionHash = publicOutputs.solutionHash;
 
     expect(solutionHash).not.toEqual(computedHash);
@@ -132,6 +149,7 @@ describe('Should generate StepProgramProof for given parameters', () => {
       secret,
       codeBreakerKey,
       codeMasterKey,
+      contractAddress,
       gameGuesses
     );
 
@@ -150,10 +168,18 @@ describe('Should generate StepProgramProof for given parameters', () => {
     );
     const attemptList = gameGuesses.totalAttempts.slice(0, rounds);
 
-    const computedHash = Poseidon.hash([...outputNumbers, salt]);
+    const computedHash = Poseidon.hash([
+      ...outputNumbers,
+      salt,
+      ...contractAddress.toFields(),
+    ]);
     let secretDigits = secret.map(Field);
 
-    const myHash = Poseidon.hash([...secretDigits, salt]);
+    const myHash = Poseidon.hash([
+      ...secretDigits,
+      salt,
+      ...contractAddress.toFields(),
+    ]);
     const solutionHash = proof.publicOutput.solutionHash;
 
     expect(myHash).toEqual(solutionHash);
@@ -179,6 +205,7 @@ describe('Should generate StepProgramProof for given parameters', () => {
       secret,
       codeBreakerKey,
       codeMasterKey,
+      contractAddress,
       gameGuesses
     );
 
@@ -198,7 +225,11 @@ describe('Should generate StepProgramProof for given parameters', () => {
     const attemptList = actions.totalAttempts.slice(0, rounds - 1);
     attemptList.push(secretCombination);
 
-    const computedHash = Poseidon.hash([...outputNumbers, salt]);
+    const computedHash = Poseidon.hash([
+      ...outputNumbers,
+      salt,
+      ...contractAddress.toFields(),
+    ]);
     const solutionHash = publicOutputs.solutionHash;
 
     expect(separatedHistory).toEqual(attemptList);
@@ -221,6 +252,7 @@ describe('Should generate StepProgramProof for given parameters', () => {
       secret,
       codeBreakerKey,
       codeMasterKey,
+      contractAddress,
       gameGuesses
     );
 
@@ -239,7 +271,11 @@ describe('Should generate StepProgramProof for given parameters', () => {
 
     const attemptList = gameGuesses.totalAttempts.slice(0, rounds);
 
-    const computedHash = Poseidon.hash([...outputNumbers, salt]);
+    const computedHash = Poseidon.hash([
+      ...outputNumbers,
+      salt,
+      ...contractAddress.toFields(),
+    ]);
     const solutionHash = publicOutputs.solutionHash;
 
     expect(separatedHistory).toEqual(attemptList);

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -201,7 +201,7 @@ function generateRandomGuess(secret: number[]): number[] {
   }
   let output = Array.from(numbers);
 
-  if (output === secret) {
+  if (secret.every((num, index) => num === output[index])) {
     return generateRandomGuess(secret);
   }
 
@@ -319,6 +319,10 @@ const generateTestProofs = async (
   contractAddress: PublicKey,
   guesses?: typeof gameGuesses
 ): Promise<StepProgramProof> => {
+  if (rounds < 1 || rounds > 7) {
+    throw new Error('Rounds must be between 1 and 7!');
+  }
+
   let lastProof = await StepProgramCreateGame(
     secret,
     salt,
@@ -349,11 +353,6 @@ const generateTestProofs = async (
           );
     return lastProof;
   } else if (flag === 'codebreaker-victory') {
-    if (rounds > 7)
-      throw new Error(
-        "Maximum attempts for codebreaker victory case can't be more than 7!"
-      );
-
     lastProof =
       guesses === undefined
         ? await generateRecursiveRandomProof(
@@ -392,12 +391,6 @@ const generateTestProofs = async (
       contractAddress
     );
   } else if (flag === 'unsolved') {
-    if (guesses)
-      if (rounds > 7)
-        throw new Error(
-          "Maximum attempts for unsolved case can't be more than 7!"
-        );
-
     lastProof =
       guesses === undefined
         ? await generateRecursiveRandomProof(

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -1,4 +1,4 @@
-import { Field, PrivateKey, Signature } from 'o1js';
+import { Field, PrivateKey, PublicKey, Signature } from 'o1js';
 import { StepProgram, StepProgramProof } from '../stepProgram.js';
 import { Combination } from '../utils.js';
 
@@ -19,7 +19,8 @@ export {
 const StepProgramCreateGame = async (
   secret: number[],
   salt: Field,
-  codeMasterKey: PrivateKey
+  codeMasterKey: PrivateKey,
+  contractAddress: PublicKey
 ): Promise<StepProgramProof> => {
   const secretCombination = Combination.from(secret);
 
@@ -29,10 +30,12 @@ const StepProgramCreateGame = async (
       authSignature: Signature.create(codeMasterKey, [
         ...secretCombination.digits,
         salt,
+        ...contractAddress.toFields(),
       ]),
     },
     secretCombination,
-    salt
+    salt,
+    contractAddress
   );
   return proof;
 };
@@ -43,7 +46,8 @@ const StepProgramCreateGame = async (
 const StepProgramMakeGuess = async (
   prevProof: StepProgramProof,
   guess: number[],
-  codeBreakerKey: PrivateKey
+  codeBreakerKey: PrivateKey,
+  contractAddress: PublicKey
 ): Promise<StepProgramProof> => {
   const guessCombination = Combination.from(guess);
   const { proof } = await StepProgram.makeGuess(
@@ -52,10 +56,12 @@ const StepProgramMakeGuess = async (
       authSignature: Signature.create(codeBreakerKey, [
         ...guessCombination.digits,
         prevProof.publicOutput.turnCount.value,
+        ...contractAddress.toFields(),
       ]),
     },
     prevProof,
-    guessCombination
+    guessCombination,
+    contractAddress
   );
   return proof;
 };
@@ -68,15 +74,24 @@ const StepProgramMakeGuessInvalidSignature = async (
     wrongPubKey: boolean;
     wrongMessage: boolean;
     wrongSigner: boolean;
-  }
+    wrongContractAddress?: boolean;
+  },
+  contractAddress: PublicKey
 ): Promise<void> => {
   const guessCombination = Combination.from(guess);
   const randomKey = PrivateKey.random();
+  const randomContractAddress = PrivateKey.random().toPublicKey();
   const authSignature = Signature.create(
     config.wrongSigner ? randomKey : codeBreakerKey,
     config.wrongMessage
       ? Array.from({ length: 4 }, () => Field.random())
-      : [...guessCombination.digits, prevProof.publicOutput.turnCount.value]
+      : [
+          ...guessCombination.digits,
+          prevProof.publicOutput.turnCount.value,
+          ...(config.wrongContractAddress
+            ? randomContractAddress.toFields()
+            : contractAddress.toFields()),
+        ]
   );
 
   await StepProgram.makeGuess(
@@ -87,7 +102,8 @@ const StepProgramMakeGuessInvalidSignature = async (
       authSignature,
     },
     prevProof,
-    guessCombination
+    guessCombination,
+    config.wrongContractAddress ? randomContractAddress : contractAddress
   );
 };
 
@@ -98,7 +114,8 @@ const StepProgramGiveClue = async (
   prevProof: StepProgramProof,
   combination: number[],
   salt: Field,
-  codeMasterKey: PrivateKey
+  codeMasterKey: PrivateKey,
+  contractAddress: PublicKey
 ): Promise<StepProgramProof> => {
   const secretCombination = Combination.from(combination);
   const { proof } = await StepProgram.giveClue(
@@ -108,11 +125,13 @@ const StepProgramGiveClue = async (
         ...secretCombination.digits,
         salt,
         prevProof.publicOutput.turnCount.value,
+        ...contractAddress.toFields(),
       ]),
     },
     prevProof,
     secretCombination,
-    salt
+    salt,
+    contractAddress
   );
   return proof;
 };
@@ -126,10 +145,13 @@ const StepProgramGiveClueInvalidSignature = async (
     wrongPubKey: boolean;
     wrongMessage: boolean;
     wrongSigner: boolean;
-  }
+    wrongContractAddress?: boolean;
+  },
+  contractAddress: PublicKey
 ): Promise<void> => {
   const secretCombination = Combination.from(combination);
   const randomKey = PrivateKey.random();
+  const randomContractAddress = PrivateKey.random().toPublicKey();
   const authSignature = Signature.create(
     config.wrongSigner ? randomKey : codeMasterKey,
     config.wrongMessage
@@ -138,6 +160,9 @@ const StepProgramGiveClueInvalidSignature = async (
           ...secretCombination.digits,
           salt,
           prevProof.publicOutput.turnCount.value,
+          ...(config.wrongContractAddress
+            ? randomContractAddress.toFields()
+            : contractAddress.toFields()),
         ]
   );
 
@@ -150,7 +175,8 @@ const StepProgramGiveClueInvalidSignature = async (
     },
     prevProof,
     secretCombination,
-    salt
+    salt,
+    config.wrongContractAddress ? randomContractAddress : contractAddress
   );
 };
 
@@ -197,19 +223,26 @@ async function generateRecursiveRandomProof(
   salt: Field,
   secret: number[],
   codeBreakerKey: PrivateKey,
-  codeMasterKey: PrivateKey
+  codeMasterKey: PrivateKey,
+  contractAddress: PublicKey
 ): Promise<StepProgramProof> {
   let guess;
   for (let i = 0; i < rounds; i++) {
     guess = generateRandomGuess(secret);
 
-    lastProof = await StepProgramMakeGuess(lastProof, guess, codeBreakerKey);
+    lastProof = await StepProgramMakeGuess(
+      lastProof,
+      guess,
+      codeBreakerKey,
+      contractAddress
+    );
 
     lastProof = await StepProgramGiveClue(
       lastProof,
       secret,
       salt,
-      codeMasterKey
+      codeMasterKey,
+      contractAddress
     );
   }
   return lastProof;
@@ -230,7 +263,8 @@ async function generateRecursiveGuessProof(
   salt: Field,
   secret: number[],
   codeBreakerKey: PrivateKey,
-  codeMasterKey: PrivateKey
+  codeMasterKey: PrivateKey,
+  contractAddress: PublicKey
 ): Promise<StepProgramProof> {
   let guess;
   const guesses = gameGuesses.totalAttempts;
@@ -246,13 +280,19 @@ async function generateRecursiveGuessProof(
   for (let i = 0; i < rounds; i++) {
     guess = guesses[i];
 
-    lastProof = await StepProgramMakeGuess(lastProof, guess, codeBreakerKey);
+    lastProof = await StepProgramMakeGuess(
+      lastProof,
+      guess,
+      codeBreakerKey,
+      contractAddress
+    );
 
     lastProof = await StepProgramGiveClue(
       lastProof,
       secret,
       salt,
-      codeMasterKey
+      codeMasterKey,
+      contractAddress
     );
   }
 
@@ -276,9 +316,15 @@ const generateTestProofs = async (
   secret: number[],
   codeBreakerKey: PrivateKey,
   codeMasterKey: PrivateKey,
+  contractAddress: PublicKey,
   guesses?: typeof gameGuesses
 ): Promise<StepProgramProof> => {
-  let lastProof = await StepProgramCreateGame(secret, salt, codeMasterKey);
+  let lastProof = await StepProgramCreateGame(
+    secret,
+    salt,
+    codeMasterKey,
+    contractAddress
+  );
 
   if (flag === 'codemaster-victory') {
     lastProof =
@@ -289,7 +335,8 @@ const generateTestProofs = async (
             salt,
             secret,
             codeBreakerKey,
-            codeMasterKey
+            codeMasterKey,
+            contractAddress
           )
         : await generateRecursiveGuessProof(
             rounds,
@@ -297,7 +344,8 @@ const generateTestProofs = async (
             salt,
             secret,
             codeBreakerKey,
-            codeMasterKey
+            codeMasterKey,
+            contractAddress
           );
     return lastProof;
   } else if (flag === 'codebreaker-victory') {
@@ -314,7 +362,8 @@ const generateTestProofs = async (
             salt,
             secret,
             codeBreakerKey,
-            codeMasterKey
+            codeMasterKey,
+            contractAddress
           )
         : await generateRecursiveGuessProof(
             rounds - 1,
@@ -322,14 +371,26 @@ const generateTestProofs = async (
             salt,
             secret,
             codeBreakerKey,
-            codeMasterKey
+            codeMasterKey,
+            contractAddress
           );
 
     // Last step that simulates the correct secret submission by codeBreaker.
-    lastProof = await StepProgramMakeGuess(lastProof, secret, codeBreakerKey);
+    lastProof = await StepProgramMakeGuess(
+      lastProof,
+      secret,
+      codeBreakerKey,
+      contractAddress
+    );
 
     // Return the last proof that result is checked by codeMaster.
-    return await StepProgramGiveClue(lastProof, secret, salt, codeMasterKey);
+    return await StepProgramGiveClue(
+      lastProof,
+      secret,
+      salt,
+      codeMasterKey,
+      contractAddress
+    );
   } else if (flag === 'unsolved') {
     if (guesses)
       if (rounds > 7)
@@ -345,7 +406,8 @@ const generateTestProofs = async (
             salt,
             secret,
             codeBreakerKey,
-            codeMasterKey
+            codeMasterKey,
+            contractAddress
           )
         : await generateRecursiveGuessProof(
             rounds,
@@ -353,7 +415,8 @@ const generateTestProofs = async (
             salt,
             secret,
             codeBreakerKey,
-            codeMasterKey
+            codeMasterKey,
+            contractAddress
           );
 
     return lastProof;


### PR DESCRIPTION
## Changes
- Overlooked wrong precondition fixed in Mastermind Contract [line 303](https://github.com/mina-builders-team/recursive-mastermind-zkApp/blob/f96b2cef2bcc4c60564a947bd9a10e79488b57bd/src/Mastermind.ts#L303) that prevents code breaker to submit guess in last turn when using off-chain recursion mode.
- Contract address added to `solutionHash` field to prevent proof replay attacks when rematch between same parties with same secret.
- More test cases added to cover upper and lower round bounds of off-chain `submitGameProof` method.
- Fixed [wrong array comparison](https://github.com/mina-builders-team/recursive-mastermind-zkApp/blob/f96b2cef2bcc4c60564a947bd9a10e79488b57bd/src/test/testUtils.ts#L178) that results solving secret unintentionally before decided round.