### PR TITLE
24 hardcoded referee

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,4 @@ jobs:
         run: npm test
         env:
           CI: true
+          REFEREE_PRIV_KEY: ${{ secrets.REFEREE_PRIV_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,11 @@ jobs:
       - name: Check code formatting
         run: npm run format:check
 
+      - name: Write .env file
+        run: |
+          echo "REFEREE_PRIV_KEY=${{ secrets.REFEREE_PRIV_KEY }}" >> .env
+
       - name: Run tests
         run: npm test
         env:
           CI: true
-          REFEREE_PRIV_KEY: ${{ secrets.REFEREE_PRIV_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ coverage
 keys
 
 /benchmarks
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@navigators-exploration-team/mina-mastermind",
       "version": "1.7.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "dotenv": "^17.2.1"
+      },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
         "@babel/preset-typescript": "^7.16.0",
@@ -3705,6 +3708,18 @@
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -35,11 +35,14 @@
     "eslint-plugin-o1js": "^0.4.0",
     "jest": "^28.1.3",
     "prettier": "^2.3.2",
+    "rimraf": "^6.0.1",
     "ts-jest": "^28.0.8",
-    "typescript": "^5.1",
-    "rimraf": "^6.0.1"
+    "typescript": "^5.1"
   },
   "peerDependencies": {
     "o1js": "^2.4.0"
+  },
+  "dependencies": {
+    "dotenv": "^17.2.1"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,9 @@
+import { PublicKey } from 'o1js';
+
 const PER_TURN_GAME_DURATION = 2;
 const MAX_ATTEMPTS = 7;
+const REFEREE_PUBKEY = PublicKey.fromBase58(
+  'B62qnbdBnbKMC1VJ9unXX9k8JfBNs4HPvo6t4rUWb43cG1bPcPEQCC5'
+);
 
-export { PER_TURN_GAME_DURATION, MAX_ATTEMPTS };
+export { PER_TURN_GAME_DURATION, MAX_ATTEMPTS, REFEREE_PUBKEY };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-import { PER_TURN_GAME_DURATION, MAX_ATTEMPTS } from './constants.js';
+import {
+  PER_TURN_GAME_DURATION,
+  MAX_ATTEMPTS,
+  REFEREE_PUBKEY,
+} from './constants.js';
 import {
   MastermindZkApp,
   NewGameEvent,
@@ -19,6 +23,7 @@ export {
   MastermindZkApp,
   PER_TURN_GAME_DURATION,
   MAX_ATTEMPTS,
+  REFEREE_PUBKEY,
   NewGameEvent,
   GameAcceptEvent,
   RewardClaimEvent,


### PR DESCRIPTION
This PR ensures that the referee public key is provided as a hardcoded value ( [REFEREE_PUBKEY](https://github.com/mina-builders-team/recursive-mastermind-zkApp/blob/b10fb8241751e0ea2c4fc32e00baa154d3a3c351/src/constants.ts#L5) ) instead of a user-supplied parameter. In this way, users are only matched with trusted referees and are protected from exposure to potentially malicious referees.

closes #24 