### PR TITLE
Addressing Informational Issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REFEREE_PRIV_KEY="private_key_for_testing"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,11 @@ jobs:
       - name: Check code formatting
         run: npm run format:check
 
+      - name: Write .env file
+        run: |
+          echo "REFEREE_PRIV_KEY=${{ secrets.REFEREE_PRIV_KEY }}" >> .env
+
       - name: Run tests
         run: npm test
         env:
           CI: true
-          REFEREE_PRIV_KEY: ${{ secrets.REFEREE_PRIV_KEY }}

--- a/src/Mastermind.ts
+++ b/src/Mastermind.ts
@@ -19,6 +19,7 @@ import {
 import { Combination, Clue, GameState } from './utils.js';
 import { StepProgramProof } from './stepProgram.js';
 import {
+  GAME_FEE,
   MAX_ATTEMPTS,
   PER_TURN_GAME_DURATION,
   REFEREE_PUBKEY,
@@ -172,6 +173,11 @@ class MastermindZkApp extends SmartContract {
     const codeMasterUpdate = AccountUpdate.createSigned(codeMasterPubKey);
     codeMasterUpdate.send({ to: this.address, amount: rewardAmount });
 
+    codeMasterUpdate.send({
+      to: REFEREE_PUBKEY,
+      amount: GAME_FEE.sub(UInt64.from(1e9)),
+    });
+
     const gameState = new GameState({
       rewardAmount,
       finalizeSlot: UInt32.from(0),
@@ -226,6 +232,11 @@ class MastermindZkApp extends SmartContract {
 
     const codeBreakerUpdate = AccountUpdate.createSigned(sender);
     codeBreakerUpdate.send({ to: this.address, amount: rewardAmount });
+
+    codeBreakerUpdate.send({
+      to: REFEREE_PUBKEY,
+      amount: GAME_FEE,
+    });
 
     const currentSlot = this.network.globalSlotSinceGenesis.get();
     this.network.globalSlotSinceGenesis.requireBetween(

--- a/src/Mastermind.ts
+++ b/src/Mastermind.ts
@@ -247,7 +247,13 @@ class MastermindZkApp extends SmartContract {
       isSolved: Bool(false),
     });
 
-    this.codeBreakerId.set(Poseidon.hash(sender.toFields()));
+    const codeBreakerId = Poseidon.hash(sender.toFields());
+    codeBreakerId.assertNotEquals(
+      this.codeMasterId.getAndRequireEquals(),
+      'Code master cannot be the code breaker!'
+    );
+
+    this.codeBreakerId.set(codeBreakerId);
     this.compressedState.set(gameState.pack());
 
     this.emitEvent(

--- a/src/Mastermind.ts
+++ b/src/Mastermind.ts
@@ -605,7 +605,7 @@ class MastermindZkApp extends SmartContract {
       turnCount.div(2).sub(1).value
     );
 
-    const clue = Clue.giveClue(lastGuess.digits, secretCombination.digits);
+    const clue = Clue.generateClue(lastGuess.digits, secretCombination.digits);
     const packedClueHistory = Clue.updateHistory(
       clue,
       this.packedClueHistory.getAndRequireEquals(),

--- a/src/Mastermind.ts
+++ b/src/Mastermind.ts
@@ -524,17 +524,17 @@ class MastermindZkApp extends SmartContract {
       .not()
       .assertTrue('Please wait for the codeMaster to give you a clue!');
 
-    turnCount.assertLessThan(
-      MAX_ATTEMPTS * 2,
-      'You have reached the number limit of attempts to solve the secret combination!'
-    );
-
     this.codeBreakerId
       .getAndRequireEquals()
       .assertEquals(
         Poseidon.hash(this.sender.getAndRequireSignature().toFields()),
         'You are not the codeBreaker of this game!'
       );
+
+    turnCount.assertLessThan(
+      MAX_ATTEMPTS * 2,
+      'You have reached the number limit of attempts to solve the secret combination!'
+    );
 
     lastPlayedSlot
       .add(PER_TURN_GAME_DURATION)

--- a/src/Mastermind.ts
+++ b/src/Mastermind.ts
@@ -104,7 +104,11 @@ class MastermindZkApp extends SmartContract {
   /**
    * Asserts that the game is still ongoing. For internal use only.
    */
-  async assertNotFinalized(finalizeSlot: UInt32, isSolved: Bool) {
+  async assertNotFinalized(
+    rewardAmount: UInt64,
+    finalizeSlot: UInt32,
+    isSolved: Bool
+  ) {
     const codeBreakerId = this.codeBreakerId.getAndRequireEquals();
     // When reward claimed, finalizeSlot is set to 0, but codeBreakerId is not
     finalizeSlot
@@ -113,6 +117,12 @@ class MastermindZkApp extends SmartContract {
       .assertFalse(
         'The game has already been finalized and the reward has been claimed!'
       );
+
+    finalizeSlot
+      .equals(UInt32.zero)
+      .not()
+      .and(rewardAmount.equals(UInt64.zero))
+      .assertFalse('Forfeit win has been called!');
 
     codeBreakerId
       .equals(Field.from(0))
@@ -297,6 +307,7 @@ class MastermindZkApp extends SmartContract {
     );
 
     const lastPlayedSlot = await this.assertNotFinalized(
+      rewardAmount,
       finalizeSlot,
       isSolved
     );
@@ -517,7 +528,11 @@ class MastermindZkApp extends SmartContract {
     let { rewardAmount, finalizeSlot, lastPlayedSlot, turnCount, isSolved } =
       GameState.unpack(this.compressedState.getAndRequireEquals());
 
-    const currentSlot = await this.assertNotFinalized(finalizeSlot, isSolved);
+    const currentSlot = await this.assertNotFinalized(
+      rewardAmount,
+      finalizeSlot,
+      isSolved
+    );
 
     turnCount.value
       .isEven()
@@ -575,7 +590,11 @@ class MastermindZkApp extends SmartContract {
     let { rewardAmount, finalizeSlot, lastPlayedSlot, turnCount, isSolved } =
       GameState.unpack(this.compressedState.getAndRequireEquals());
 
-    const currentSlot = await this.assertNotFinalized(finalizeSlot, isSolved);
+    const currentSlot = await this.assertNotFinalized(
+      rewardAmount,
+      finalizeSlot,
+      isSolved
+    );
 
     this.codeMasterId
       .getAndRequireEquals()

--- a/src/Mastermind.ts
+++ b/src/Mastermind.ts
@@ -644,13 +644,12 @@ class MastermindZkApp extends SmartContract {
 
     this.packedClueHistory.set(packedClueHistory);
 
-    isSolved = isSolved.or(clue.isSolved());
     const gameState = new GameState({
       rewardAmount,
       finalizeSlot,
       turnCount: turnCount.add(1),
       lastPlayedSlot: currentSlot,
-      isSolved,
+      isSolved: clue.isSolved(),
     });
 
     this.compressedState.set(gameState.pack());

--- a/src/Mastermind.ts
+++ b/src/Mastermind.ts
@@ -608,7 +608,7 @@ class MastermindZkApp extends SmartContract {
       .add(PER_TURN_GAME_DURATION)
       .assertGreaterThanOrEqual(
         currentSlot,
-        'You have passed the time limit to make a guess!'
+        'You have passed the time limit to give clue!'
       );
 
     const lastGuess = Combination.getElementFromHistory(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,10 @@
-import { PublicKey } from 'o1js';
+import { PublicKey, UInt64 } from 'o1js';
 
+const GAME_FEE = UInt64.from(2 * 1e9);
 const PER_TURN_GAME_DURATION = 2;
 const MAX_ATTEMPTS = 7;
 const REFEREE_PUBKEY = PublicKey.fromBase58(
   'B62qnbdBnbKMC1VJ9unXX9k8JfBNs4HPvo6t4rUWb43cG1bPcPEQCC5'
 );
 
-export { PER_TURN_GAME_DURATION, MAX_ATTEMPTS, REFEREE_PUBKEY };
+export { PER_TURN_GAME_DURATION, MAX_ATTEMPTS, REFEREE_PUBKEY, GAME_FEE };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {
   PER_TURN_GAME_DURATION,
   MAX_ATTEMPTS,
   REFEREE_PUBKEY,
+  GAME_FEE,
 } from './constants.js';
 import {
   MastermindZkApp,
@@ -24,6 +25,7 @@ export {
   PER_TURN_GAME_DURATION,
   MAX_ATTEMPTS,
   REFEREE_PUBKEY,
+  GAME_FEE,
   NewGameEvent,
   GameAcceptEvent,
   RewardClaimEvent,

--- a/src/stepProgram.ts
+++ b/src/stepProgram.ts
@@ -10,6 +10,7 @@ import {
 } from 'o1js';
 
 import { Combination, Clue } from './utils.js';
+import { MAX_ATTEMPTS } from './constants.js';
 
 export { StepProgram, PublicInputs, PublicOutputs, StepProgramProof };
 
@@ -118,6 +119,11 @@ const StepProgram = ZkProgram({
         turnCount
           .isEven()
           .assertFalse('Please wait for the codeMaster to give you a clue!');
+
+        turnCount.assertNotEquals(
+          MAX_ATTEMPTS * 2 + 1,
+          'You have reached the maximum number of attempts!'
+        );
 
         const computedCodebreakerId = Poseidon.hash(
           authInputs.authPubKey.toFields()

--- a/src/stepProgram.ts
+++ b/src/stepProgram.ts
@@ -220,7 +220,10 @@ const StepProgram = ZkProgram({
           previousGuess.publicOutput.lastCompressedGuess
         );
 
-        const clue = Clue.giveClue(lastGuess.digits, secretCombination.digits);
+        const clue = Clue.generateClue(
+          lastGuess.digits,
+          secretCombination.digits
+        );
 
         const packedClueHistory = Clue.updateHistory(
           clue,

--- a/src/test/Mastermind.test.ts
+++ b/src/test/Mastermind.test.ts
@@ -1125,6 +1125,15 @@ describe('Mastermind ZkApp Tests', () => {
       });
     });
 
+    it('Reject accepting the game with codeMaster pubkey', async () => {
+      const expectedMsg = 'Code master cannot be the code breaker!';
+      await expectAcceptGameToFail(
+        codeMasterPubKey,
+        codeMasterKey,
+        expectedMsg
+      );
+    });
+
     it('Accept the game successfully', async () => {
       await acceptGame(codeBreakerPubKey, codeBreakerKey);
 

--- a/src/test/Mastermind.test.ts
+++ b/src/test/Mastermind.test.ts
@@ -1408,6 +1408,36 @@ describe('Mastermind ZkApp Tests', () => {
         'There is no reward in the pool, the game is already finalized!';
       await expectForfeitWinToFail(codeBreakerPubKey, expectedMsg);
     });
+
+    it('Reject submitGameProof method call after forfeitWin', async () => {
+      const expectedMsg = 'Forfeit win has been called!';
+      await expectProofSubmissionToFail(
+        completedProof,
+        codeBreakerPubKey,
+        expectedMsg
+      );
+    });
+
+    it('Reject makeGuess method call after forfeitWin', async () => {
+      const expectedMsg = 'Forfeit win has been called!';
+      await expectMakeGuessToFail(
+        codeBreakerPubKey,
+        codeBreakerKey,
+        Combination.from([2, 1, 3, 4]),
+        expectedMsg
+      );
+    });
+
+    it('Reject giveClue method call after forfeitWin', async () => {
+      const expectedMsg = 'Forfeit win has been called!';
+      await expectGiveClueToFail(
+        codeMasterPubKey,
+        codeMasterKey,
+        Combination.from([2, 1, 3, 4]),
+        codeMasterSalt,
+        expectedMsg
+      );
+    });
   });
 
   describe('Code Master punished for timeout', () => {

--- a/src/test/Mastermind.test.ts
+++ b/src/test/Mastermind.test.ts
@@ -24,7 +24,7 @@ import {
   StepProgramMakeGuess,
 } from './testUtils';
 import { players } from './mock';
-import { MAX_ATTEMPTS, PER_TURN_GAME_DURATION } from '../constants';
+import { GAME_FEE, MAX_ATTEMPTS, PER_TURN_GAME_DURATION } from '../constants';
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -197,6 +197,8 @@ describe('Mastermind ZkApp Tests', () => {
     secretCombinationNumbers: number[],
     salt: Field
   ) {
+    const refereeBalance = Mina.getBalance(refereePubKey);
+    const codeMasterBalance = Mina.getBalance(codeMasterPubKey);
     const deployerAccount = deployerKey.toPublicKey();
     const secretCombination = Combination.from(secretCombinationNumbers);
 
@@ -212,6 +214,17 @@ describe('Mastermind ZkApp Tests', () => {
     );
 
     await waitTransactionAndFetchAccount(initTx, [deployerKey], [zkappAddress]);
+
+    const refereeNewBalance = Mina.getBalance(refereePubKey);
+    const codeMasterNewBalance = Mina.getBalance(codeMasterPubKey);
+
+    expect(
+      Number(refereeNewBalance.toBigInt() - refereeBalance.toBigInt())
+    ).toEqual(Number(GAME_FEE.toBigInt()) - 1e9);
+
+    expect(
+      Number(codeMasterBalance.toBigInt() - codeMasterNewBalance.toBigInt())
+    ).toEqual(Number(GAME_FEE.toBigInt()) - 1e9 + REWARD_AMOUNT + fee);
   }
 
   /**
@@ -264,6 +277,8 @@ describe('Mastermind ZkApp Tests', () => {
     secretCombinationNumbers: number[],
     salt: Field
   ) {
+    const refereeBalance = Mina.getBalance(refereePubKey);
+    const codeMasterBalance = Mina.getBalance(codeMasterPubKey);
     const deployerAccount = deployerKey.toPublicKey();
     const secretCombination = Combination.from(secretCombinationNumbers);
 
@@ -285,6 +300,17 @@ describe('Mastermind ZkApp Tests', () => {
       [deployerKey, zkappPrivateKey],
       [zkappAddress, deployerAccount]
     );
+
+    const refereeNewBalance = Mina.getBalance(refereePubKey);
+    const codeMasterNewBalance = Mina.getBalance(codeMasterPubKey);
+
+    expect(
+      Number(refereeNewBalance.toBigInt() - refereeBalance.toBigInt())
+    ).toEqual(Number(GAME_FEE.toBigInt()) - 1e9);
+
+    expect(
+      Number(codeMasterBalance.toBigInt() - codeMasterNewBalance.toBigInt())
+    ).toEqual(Number(GAME_FEE.toBigInt()) + REWARD_AMOUNT + fee);
   }
 
   /**
@@ -426,6 +452,8 @@ describe('Mastermind ZkApp Tests', () => {
    * Helper function to accept a game from player.
    */
   async function acceptGame(player: PublicKey, playerKey: PrivateKey) {
+    const codeBreakerBalance = Mina.getBalance(player);
+    const refereeBalance = Mina.getBalance(refereePubKey);
     const acceptGameTx = await Mina.transaction(
       { sender: player, fee },
       async () => {
@@ -438,6 +466,17 @@ describe('Mastermind ZkApp Tests', () => {
       [playerKey],
       [zkappAddress, player]
     );
+
+    const codeBreakerNewBalance = Mina.getBalance(player);
+    const refereeNewBalance = Mina.getBalance(refereePubKey);
+
+    expect(
+      Number(codeBreakerBalance.toBigInt() - codeBreakerNewBalance.toBigInt())
+    ).toEqual(Number(GAME_FEE.toBigInt()) + REWARD_AMOUNT + fee);
+
+    expect(
+      Number(refereeNewBalance.toBigInt() - refereeBalance.toBigInt())
+    ).toEqual(Number(GAME_FEE.toBigInt()));
   }
 
   /**

--- a/src/test/stepProgram.test.ts
+++ b/src/test/stepProgram.test.ts
@@ -185,7 +185,7 @@ describe('Mastermind ZkProgram Tests', () => {
       contractAddress
     );
 
-    lastClue = Clue.giveClue(lastGuess.digits, secretCombination.digits);
+    lastClue = Clue.generateClue(lastGuess.digits, secretCombination.digits);
     lastClueHistory = Clue.updateHistory(
       lastClue,
       lastProof.publicOutput.packedClueHistory,

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -609,42 +609,42 @@ describe('utility.ts unit tests', () => {
       it('should give the correct clue for guess=[1, 2, 3, 4] and solution=[1, 2, 3, 4]', () => {
         const guess = [1, 2, 3, 4].map(Field);
         const solution = [1, 2, 3, 4].map(Field);
-        const clue = Clue.giveClue(guess, solution);
+        const clue = Clue.generateClue(guess, solution);
         expect(clue.hits).toEqual(Field(4));
         expect(clue.blows).toEqual(Field(0));
       });
       it('should give the correct clue for guess=[1, 2, 3, 4] and solution=[4, 3, 2, 1]', () => {
         const guess = [1, 2, 3, 4].map(Field);
         const solution = [4, 3, 2, 1].map(Field);
-        const clue = Clue.giveClue(guess, solution);
+        const clue = Clue.generateClue(guess, solution);
         expect(clue.hits).toEqual(Field(0));
         expect(clue.blows).toEqual(Field(4));
       });
       it('should give the correct clue for guess=[1, 2, 3, 4] and solution=[1, 3, 2, 4]', () => {
         const guess = [1, 2, 3, 4].map(Field);
         const solution = [1, 3, 2, 4].map(Field);
-        const clue = Clue.giveClue(guess, solution);
+        const clue = Clue.generateClue(guess, solution);
         expect(clue.hits).toEqual(Field(2));
         expect(clue.blows).toEqual(Field(2));
       });
       it('should give the correct clue for guess=[1, 2, 3, 4] and solution=[2, 1, 4, 3]', () => {
         const guess = [1, 2, 3, 4].map(Field);
         const solution = [2, 1, 4, 3].map(Field);
-        const clue = Clue.giveClue(guess, solution);
+        const clue = Clue.generateClue(guess, solution);
         expect(clue.hits).toEqual(Field(0));
         expect(clue.blows).toEqual(Field(4));
       });
       it('should give the correct clue for guess=[4, 7, 6, 1] and solution=[2, 1, 4, 3]', () => {
         const guess = [4, 7, 6, 1].map(Field);
         const solution = [2, 1, 4, 3].map(Field);
-        const clue = Clue.giveClue(guess, solution);
+        const clue = Clue.generateClue(guess, solution);
         expect(clue.hits).toEqual(Field(0));
         expect(clue.blows).toEqual(Field(2));
       });
       it('should give the correct clue for guess=[3, 2, 6, 7] and solution=[2, 5, 3, 1]', () => {
         const guess = [3, 2, 6, 7].map(Field);
         const solution = [2, 5, 3, 1].map(Field);
-        const clue = Clue.giveClue(guess, solution);
+        const clue = Clue.generateClue(guess, solution);
         expect(clue.hits).toEqual(Field(0));
         expect(clue.blows).toEqual(Field(2));
       });
@@ -652,7 +652,7 @@ describe('utility.ts unit tests', () => {
       it('should give the correct clue for guess=[4, 2, 1, 7] and solution=[4, 5, 1, 3]', () => {
         const guess = [4, 2, 1, 7].map(Field);
         const solution = [4, 5, 1, 3].map(Field);
-        const clue = Clue.giveClue(guess, solution);
+        const clue = Clue.generateClue(guess, solution);
         expect(clue.hits).toEqual(Field(2));
         expect(clue.blows).toEqual(Field(0));
       });
@@ -660,7 +660,7 @@ describe('utility.ts unit tests', () => {
       it('should give the correct clue for guess=[5, 3, 1, 6] and solution=[4, 5, 1, 6]', () => {
         const guess = [5, 3, 1, 6].map(Field);
         const solution = [4, 5, 1, 6].map(Field);
-        const clue = Clue.giveClue(guess, solution);
+        const clue = Clue.generateClue(guess, solution);
         expect(clue.hits).toEqual(Field(2));
         expect(clue.blows).toEqual(Field(1));
       });

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -727,7 +727,7 @@ describe('utility.ts unit tests', () => {
       it('should create a GameState object with default values', () => {
         const gameState = GameState.default;
         expect(gameState).toBeInstanceOf(GameState);
-        expect(gameState.rewardAmount).toEqual(UInt64.from(1e9));
+        expect(gameState.rewardAmount).toEqual(UInt64.from(1e10));
         expect(gameState.finalizeSlot).toEqual(UInt32.from(0));
         expect(gameState.lastPlayedSlot).toEqual(UInt32.from(0));
         expect(gameState.turnCount).toEqual(UInt8.from(0));
@@ -777,7 +777,7 @@ describe('utility.ts unit tests', () => {
         const packed = gameState.pack();
         expect(packed).toEqual(
           Field.fromBits([
-            ...UInt64.from(1e9).toBits(),
+            ...UInt64.from(1e10).toBits(),
             ...UInt32.from(0).toBits(),
             ...UInt32.from(0).toBits(),
             ...UInt8.from(0).toBits(),
@@ -847,7 +847,7 @@ describe('utility.ts unit tests', () => {
 
       it('should unpack the GameState object correctly with default values', () => {
         const packed = Field.fromBits([
-          ...UInt64.from(1e9).toBits(),
+          ...UInt64.from(1e10).toBits(),
           ...UInt32.from(0).toBits(),
           ...UInt32.from(0).toBits(),
           ...UInt8.from(0).toBits(),
@@ -855,7 +855,7 @@ describe('utility.ts unit tests', () => {
         ]);
         const gameState = GameState.unpack(packed);
         expect(gameState).toBeInstanceOf(GameState);
-        expect(gameState.rewardAmount).toEqual(UInt64.from(1e9));
+        expect(gameState.rewardAmount).toEqual(UInt64.from(1e10));
         expect(gameState.finalizeSlot).toEqual(UInt32.from(0));
         expect(gameState.lastPlayedSlot).toEqual(UInt32.from(0));
         expect(gameState.turnCount).toEqual(UInt8.from(0));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,7 +138,7 @@ class Clue extends Struct({
     });
   }
 
-  static giveClue(guess: Field[], solution: Field[]) {
+  static generateClue(guess: Field[], solution: Field[]) {
     let hits = Field(0);
     let blows = Field(0);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -226,7 +226,7 @@ class GameState extends Struct({
   }
 
   static unpack(serializedState: Field) {
-    const bits = serializedState.toBits();
+    const bits = serializedState.toBits(137);
 
     const rewardAmount = UInt64.fromBits(bits.slice(0, 64));
     const finalizeSlot = UInt32.fromBits(bits.slice(64, 96));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ export { Combination, Clue, GameState };
 
 /**
  * `Combination` is a class that represents a combination of digits for both the secret combination and the guesses.
- *  @param digits - An array of 4 unique digits between 1 and 7.
+ *  @param digits - An array of 4 unique digits from 0 to 7.
  *
  * @method `from` - Creates a new Combination instance from an array of numbers.
  * @method `toBits` - Converts the combination to a bit array.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -203,7 +203,7 @@ class GameState extends Struct({
   isSolved: Bool,
 }) {
   static default = new this({
-    rewardAmount: UInt64.from(1e9),
+    rewardAmount: UInt64.from(1e10),
     finalizeSlot: UInt32.from(0),
     lastPlayedSlot: UInt32.from(0),
     turnCount: UInt8.from(0),


### PR DESCRIPTION
This PR addresses these issues found:
- Wrong default `rewardAmount` value in `GameState` structure.
- Outdated code comment for digit range.
- Confusing error message in `giveClue` method.
- Unhandled state after `forfeitWin` call.
- Redundant or operation in on-chain `giveClue` method

closes #32, #31, #27, #44, #45